### PR TITLE
Hide ToC of page within navigation of all pages

### DIFF
--- a/docs/css/hide_toc.css
+++ b/docs/css/hide_toc.css
@@ -1,0 +1,9 @@
+/* Hide table of contents of a specific page */
+.wm-page-toc .wm-toctree {
+    display: none;
+}
+
+/* Hide caret at the end of the current open page */
+.wm-page-toc-opener.wm-page-toc-open > .wm-toc-text::after {
+    display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,3 +96,6 @@ nav:
 - Glossary: 'glossary.md'
   
 theme: windmill
+
+extra_css:
+  - css/hide_toc.css


### PR DESCRIPTION
A picture is worth a thousand words:

<img width="254" alt="Bildschirmfoto 2020-11-27 um 09 41 39" src="https://user-images.githubusercontent.com/7300329/100429008-0493fd80-3095-11eb-8e65-a3d9e42f8fcd.png">
