### PR TITLE
Rename question types consistently

### DIFF
--- a/docs/bestpractices/quizdesign.md
+++ b/docs/bestpractices/quizdesign.md
@@ -17,44 +17,44 @@ The University of Texas provides some [good advice](https://facultyinnovate.utex
 
 ## Self-Tests
 
-Self-tests help repeating and deepening the learnings from the previously seen video clips. Content-wise, questions should be designed in a way, that they take up the most important learnings and findings from the videos. 
+Self-tests help repeating and deepening the learnings from the previously seen video clips. Content-wise, questions should be designed in a way, that they take up the most important learnings and findings from the videos.
 Alternatively, self-tests can also be used to encourage the students to deepen their knowledge, e.g. with some research of their own.
 Depending on length and level of difficulty, video content should be reflected within 2-5 questions.
-The points users can earn for self-tests should, in general, match with the ones from the weekly assignments. The number of points for a question depends on its type and the level of difficulty. In general, multiple-answer-questions are considered to be more difficult than multiple-choice-questions. 
+The points users can earn for self-tests should, in general, match with the ones from the weekly assignments. The number of points for a question depends on its type and the level of difficulty. In general, multiple-answer-questions are considered to be more difficult than multiple-choice-questions.
 
 Questions with more answers to choose from should earn more points. The amount of points should not match the number of correct answers, however.
 For multiple-answer-questions, the points a user will receive are calculated according to their correct answers. The value of the result is determined by the sum of correct answers. If a student marks a correct answer as correct, he/she will receive the according part of the total points. If a student marks a wrong answer as correct, the according part of the total points will be deducted. Minimum points are always zero, there are no negative points.
 
-	Example: 
+	Example:
 
-	- Question with four answers to chose from: 
-		- 2 answers are correct, 
-		- 2 answers are wrong. 
+	- Question with four answers to chose from:
+		- 2 answers are correct,
+		- 2 answers are wrong.
 		- The teaching team decided to award this questions with 4 points.  
 
 	- Student one:
-	   - Marked two answers as correct. 
+	   - Marked two answers as correct.
 	   - Both of the answers have been marked as correct by the teaching team as well.
 	   ==> Student one will receive 4 points.
 
 	- Student two:
-	   - Marked one answer as correct. 
+	   - Marked one answer as correct.
 	   - The answer has been marked as correct by the teaching team as well.
 	   ==> Student two will receive 2 points.  
 
 	- Student three:
-      - Marked two answers as correct. 
+      - Marked two answers as correct.
       - One of the answers is correct, the other one is wrong.
       ==> Student three will receive 0 points.
 
  	- Student four:
-      - Marked two answers as correct. 
+      - Marked two answers as correct.
       - Both answers are wrong.
       ==> Student four will receive 0 points.   
 
 
 
-**We strongly discourage to tell the students how many answers are correct in a multiple answer question.** Practice has shown that this increases the need for re-gradings, while simultaneously reducing the choice of possible re-gradings.
+**We strongly discourage to tell the students how many answers are correct in a Multi Select question.** Practice has shown that this increases the need for re-gradings, while simultaneously reducing the choice of possible re-gradings.
 
 
 
@@ -69,10 +69,10 @@ For multiple-answer-questions, the points a user will receive are calculated acc
 
 ![add section](../img/06/weekly_assignments.png)
 
-*Fig. An example about weekly assignments* 
+*Fig. An example about weekly assignments*
 
 
-The performance of openHPI learners is measured with weekly assignments and a final exam. 
+The performance of openHPI learners is measured with weekly assignments and a final exam.
 
 **We suggest to allocate a total of 180 points per course:**
 
@@ -89,7 +89,7 @@ For weekly assignments and the final exam, we suggest to set a time limit and to
 - Final exam: 1 attempt, 120 minutes
 
 Some teaching teams have gained good experience with more narrow time slots. This way a *closed book exam* can be simulated.
-As this setting is rather unusual on the platform it can (will) lead to undesired help desk traffic and forum posts. 
+As this setting is rather unusual on the platform it can (will) lead to undesired help desk traffic and forum posts.
 
 In case of e.g. technical problems, a second attempt can be given to affected users individually. This is only possible, however, before the deadline of the quiz has passed.
 
@@ -122,30 +122,29 @@ Possible mistakes during quiz design, which can lead to a regrading, can be as f
 **Remove question:**
 A complete question could be removed from the quiz. As this leads to undesired side effects, such as the recalculation of the amount of overall points, this should be avoided. A Jackpot regrading might be the better choice.
 
-**Add additional correct answer (multiple choice only):** For multiple choice questions additional answers can be checked as correct. This also requires the update skript to be run. If applied to a multiple answer question, the amount of points per answer might change, users that answered the question as it was originally intended will lose points.
+**Add additional correct answer (Single Select only):** For Single Select questions additional answers can be checked as correct. This also requires the update skript to be run. If applied to a Multi Select question, the amount of points per answer might change, users that answered the question as it was originally intended will lose points.
 
 
 
 ![edit quiz - overview](../img/06/question1_quiz.png)
 
-*Fig. Edit questions of the quiz* 
+*Fig. Edit questions of the quiz*
 
 
 
 
 ![edit quiz - add new question](../img/06/question2_quiz.png)
 
-*Fig. Add a new question to the quiz* 
+*Fig. Add a new question to the quiz*
 
 
 
 
 ![example quiz](../img/06/quiz_example.png)
 
-*Fig. An example from the corrected quiz* 
+*Fig. An example from the corrected quiz*
 
 
 ## Background information – Quiz-Engine
 
 Quizzes in openHPI are saved "versionized", which means that each editing (and publication) of a quiz generates a new version. If a user wants to take the quiz, a copy with the latest version of that quiz is stored in a database table. Therefore, a modification of the already released quiz doesn’t have an impact on already submitted questions. Some - (e.g. Jackpot) only corrects the POINTS for submitted answers, not the answers themselves. So please be aware that an inconsistency between correct answers of a student and her points can arise.
-

--- a/docs/courseadministration/addcontent/learningunits/quiz.md
+++ b/docs/courseadministration/addcontent/learningunits/quiz.md
@@ -23,7 +23,7 @@ Quizzes of type **Main** are the weekly assignments (WA) or the final exam (FE).
 
 Quizzes of type **Bonus** are not summing up to the MaxPoints, but they can help to compensate points that have been lost in the **Main** assignments.
 
-Example: 
+Example:
 
 - WA 1 (Main): 15 points
 - WA 2 (Main): 15 points
@@ -44,7 +44,7 @@ The participants can achieve a maximum of 90 points.
 	==> 71 points  
 
 
-	User 2: 
+	User 2:
 
 	- WA 1 (Main): 15 points
 	- WA 2 (Main): 15 points
@@ -54,11 +54,11 @@ The participants can achieve a maximum of 90 points.
 
 	==> 90 points
 
-**Surveys** are not rewarded with points, nevertheless, to avoid problems it is better to assign at least 1 point to a survey question. FreeText answers require that at least one answer (dummy) is provided, which needs to be marked as correct. Otherwise, the system will break. 
+**Surveys** are not rewarded with points, nevertheless, to avoid problems it is better to assign at least 1 point to a survey question. FreeText answers require that at least one answer (dummy) is provided, which needs to be marked as correct. Otherwise, the system will break.
 
 **Quizzes come with the optimal presets for their exercise type preselected. Change these settings only if you know exactly what you are doing.**
 
-**Maximal points:** These are the maximal points that can be reached for this assignment. The value is read only and results from the sum of the points for the quizzes' questions 
+**Maximal points:** These are the maximal points that can be reached for this assignment. The value is read only and results from the sum of the points for the quizzes' questions
 
 **Submission deadline:** Set the deadline for the quiz. The deadline is hard. After this date it is no more possible to hand in a solution. The results of the participants are autosaved whenever something has changed. When the deadline has passed and the participant is still in the quiz, the results are automatically submitted and the quiz is closed. It is not possible to extend the deadline for single users.  
 
@@ -79,7 +79,7 @@ This of course can be adjusted to your needs. If you e.g. want to make sure that
 
 ![adding quiz](../../../img/05/quiz3.png)
 
-*Fig. Create new quiz* 
+*Fig. Create new quiz*
 
 
 
@@ -89,13 +89,13 @@ The platform offers the possibility to add graphics or images (best suited are P
 
 ### Available question types:
 
-* **Multiple choice:** Multiple options but only one correct answer. Displayed with radio buttons to signal the user that only one of the options is correct.
+* **Single Select:** Multiple options but only one correct answer. Displayed with radio buttons to signal the user that only one of the options is correct.
 
-* **Multiple answer:** Multiple options, more than one possibly correct answer. Displayed with check boxes to signal the user that more options might be correct. It is also possible to use this question type with only one correct answer to raise the difficulty of a multiple choice question.
+* **Multi Select:** Multiple options, more than one possibly correct answer. Displayed with check boxes to signal the user that more options might be correct. It is also possible to use this question type with only one correct answer to raise the difficulty of a Single Select question.
 
 	*Note: once the type of a question has been saved it cannot be changed anymore.*
 
-* **Free Text:** Only for short texts. Correctness is tested by direct string comparison. 
+* **Free Text:** Only for short texts. Correctness is tested by direct string comparison.
 A correct answer must be specified in the quiz setup, otherwise the quiz will crash.
 
 	*Note: we use this type of question only for special purposes, e.g. when a password can be retrieved by solving an external task.*
@@ -120,7 +120,7 @@ A correct answer must be specified in the quiz setup, otherwise the quiz will cr
 *Fig. Add question and explanation*
 
 
-**Question type:** can be any of *Multiple Choice*, *Multiple Answer*, *Essay* or *Free Text*
+**Question type:** can be any of *Single Select*, *Multi Select*, *Essay* or *Free Text*
 
 **Question text:** the actual question
 
@@ -135,4 +135,3 @@ A correct answer must be specified in the quiz setup, otherwise the quiz will cr
 
 ![course structure](../../../img/07/add_answers_sample.png)  
 *Fig. Add new answers*
-

--- a/docs/features/itemtypes/quiz.md
+++ b/docs/features/itemtypes/quiz.md
@@ -6,9 +6,9 @@ A quiz consists of questions and the corresponding answers.
 The points to be awarded are configured per question.  
 Additional explanatory texts may be added to the questions and answers.  
 The answer options are marked as correct or incorrect by the teaching team behind the scenes.  
-Answers to a question can be configured to be shown in random order. 
+Answers to a question can be configured to be shown in random order.
 Explanatory texts are only visible to a participant when the solution has been subitted and the results are published.
-  
+
 <br>
 ![Sample quiz](../../img/features/itemtypes/quiz.png)  
 
@@ -17,19 +17,19 @@ Explanatory texts are only visible to a participant when the solution has been s
 
 So far there are four different types of questions to choose from:  
 
-* Multiple choice questions (ONLY ONE correct answer) 
-* Multiple answer questions (MORE THAN ONE possible correct answers)
-* Free-text questions (with a configurable list of correct answers) 
+* Single select questions (ONLY ONE correct answer)
+* Multi Select questions (MORE THAN ONE possible correct answers)
+* Free-text questions (with a configurable list of correct answers)
 * Essay questions (not evaluated automatically)
 
 With the exception of essay questions, the evaluation of quizzes is a fully automatic operation. The evaluation for automatically graded questions are listed below with an example:  
 
-* ### Multiple Choice Question:  
+* ### Single Select Question:  
     There is only one correct answer.  
     For the correct answer, the specified number of points for the task will be awarded.  
     The participant receives 0 points for an incorrect answer.   
 
-* ### Multiple Answer Question:   
+* ### Multi Select Question:   
     There are more than one possible answers.  
     The maximum number of points possible is divided by the number of correct alternatives.
     The resulting value is used as the base value.  
@@ -45,7 +45,7 @@ With the exception of essay questions, the evaluation of quizzes is a fully auto
 
 <br>
 
-The platform provides a user interface to create quizzes. Alternatively, quizzes can be imported from Google Spreadsheets and via an XML import format. Please contact your platform administrator for further instructions to work with the import formats. 
+The platform provides a user interface to create quizzes. Alternatively, quizzes can be imported from Google Spreadsheets and via an XML import format. Please contact your platform administrator for further instructions to work with the import formats.
 
 As all item types, quizzes in a course are located within a course section.  
 
@@ -62,24 +62,24 @@ To learn more about creating and configuring quizzes, please refer to [Quiz Desi
 Despite the quality control and great care taken in creating the tests, the possibility of errors or ambiguities cannot be wholly eliminated. If for some reason an error has slipped into one of the questions, there are different ways of re-grading it:  
 
 * Re-grading scripts can be used to regenerate point calculation for all participants.
-* It is also possible to credit individual participants with points. 
+* It is also possible to credit individual participants with points.
 * Before expiration of the deadline, extra attempts can be activated individually on a per participant basis.
 
 The following re-grading options are supported by the HPI platform:   
 
-* ### Multiple Correct Answers for Multiple Choice Questions:  
-    In multiple choice questions, additional answers can be marked as correct after the fact.  
+* ### Multiple Correct Answers for Single Select Questions:  
+    In Single Select questions, additional answers can be marked as correct after the fact.  
     All participants who have selected one of the newly marked correct answers will receive the full number of points.  
 
-* ### Removing an Answer: 
-    In multiple answer questions, both correct and incorrect answers can be removed at a later date.  
+* ### Removing an Answer:
+    In Multi Select questions, both correct and incorrect answers can be removed at a later date.  
     The points are then re-calculated for all participants.  
     It is possible that some participants will end up with fewer points than before the re-grading.
 
     >**Example**:  
     One of the wrong answers given was ambiguously formulated.
 
-* ### Choosing One Answer for all Participants: 
+* ### Choosing One Answer for all Participants:
     Here one specific answer is chosen for all participants.  
     The points are then recalculated.  
     Afterwards, all participants involved will have more points.  
@@ -88,7 +88,7 @@ The following re-grading options are supported by the HPI platform:
     One of the answers given as correct was formulated ambiguously.  
     Some participants decided to play it safe and chose not to select the answer.
 
-* ### Adding an Answer: 
+* ### Adding an Answer:
     Other correct answers can be added at a later date for free-text questions.  
 
 
@@ -102,16 +102,16 @@ The following re-grading options are supported by the HPI platform:
     Alternatively, the full number of points could be given to all participants who took the test but did not answer that particular question.  
 
     >**Example**:  
-    When none of the other mechanisms apply. 
-    
+    When none of the other mechanisms apply.
+
 Please contact your platform administrator if you have to regrade on of your quizzes.
-  
+
 <br>
 
 A quiz can be used as a self-test or a graded test:  
 
 * In the self-checking function, the correct answers are displayed immediately after the self-test has been completed.  
-  
+
 * In the case of the graded test, the results are time-delayed following expiration of the set publication date to prevent discussions from occurring too early.  
 
 Furthermore, quizzes can be defined as a bonus exercise. In this case, the quiz is similar to a graded quiz except that the points earned are only used to make up for missing points on other quizzes.
@@ -122,7 +122,7 @@ Furthermore, quizzes can be defined as a bonus exercise. In this case, the quiz 
 One weekly evaluated task: worth *15* points each  
 One final test: *90* points  
 One bonus task: *10* points  
-Approx. 30 self-tests: worth *4* points each (*120* points total) 
+Approx. 30 self-tests: worth *4* points each (*120* points total)
 >
 >
 >Maximum possible points in the course: ***[(6 x 15) 90 + 90]*** = ***180*** points  
@@ -143,7 +143,7 @@ Participant also achieves the maximum *10* points on the bonus task
 >
 >**Result**:  
 ***(6 x 15) + 90 + 10*** = ***190*** points.  
-The result is capped at the maximum achievable ***180*** points 
+The result is capped at the maximum achievable ***180*** points
 >
 >For both participants, the points scored on the self-test have no bearing on the result.
 


### PR DESCRIPTION
Question types have been renamed:
- Multiple Choice -> Single Select
- Multiple Answer -> Multi Select

There is another occurrence of "Multiple Choice" in the [Quiz Design remarks](https://github.com/openHPI/TeachingTeamGuidelines/blame/master/docs/bestpractices/quizdesign.md#L7). As this is more a general remark referring to the type of our quizzes in general, I kept it here.

Some whitespaces have been removed (automatically) in addition.
